### PR TITLE
manjaro_arch_setup.sh: Improve parsing java version

### DIFF
--- a/setup/manjaro_arch_setup.sh
+++ b/setup/manjaro_arch_setup.sh
@@ -29,8 +29,8 @@ echo "--> Checking for a compatible Java version (>=17)..."
 
 JAVA_OK=0
 if command -v java &> /dev/null; then
-    # Get major version number
-    VERSION=$(java -version 2>&1 | awk -F'[."]' '/version/ {print $2}')
+    # Get major version (handle Java 8 and 9+)
+    VERSION=$(java -version 2>&1 | awk -F[\".] '/version/ {print ($2 == "1") ? $3 : $2}')
     if [ "$VERSION" -ge 17 ]; then
         echo "    -> Found compatible Java version $VERSION. OK."
         JAVA_OK=1


### PR DESCRIPTION
Your script works on systems using `pacman` (like Arch/Manjaro), but it has a **bug in how it parses the Java version**, especially for newer Java versions (17+), because:

* Java 9+ uses a **new versioning scheme**, e.g., `17.0.9`, `21.0.1`.
* Your current `awk` line extracts the second field (after the first dot), which doesn't yield the major version for Java 17+.

---

### ✅ Fix: Parse version properly

Update your `awk` to handle both pre-Java-9 and Java-9+ version formats:

```bash
VERSION=$(java -version 2>&1 | awk -F[\".] '/version/ {print $2}')
```

Change to:

```bash
VERSION=$(java -version 2>&1 | awk -F[\".] '/version/ {print ($2 == "1") ? $3 : $2}')
```

This properly handles:

* `1.8.0_XXX` → 8
* `17.0.9` → 17
* `21.0.1` → 21
