### PR TITLE
Feat/macos compatibility

### DIFF
--- a/config/languagetool_server/maps/de-DE/FUZZY_MAP.py
+++ b/config/languagetool_server/maps/de-DE/FUZZY_MAP.py
@@ -23,6 +23,10 @@ mitkomm mit
 """
 
 FUZZY_MAP = [
+
+    ('pull requests', r'^pull requests$', 82),
+    ('pull requests', r'^Pullover Quest$', 82),
+
     # --- git status ---
     ('git status', r'^git status$', 82),
     ('git status', r'^geht status$', 82),

--- a/scripts/restart_venv_and_run-server.sh
+++ b/scripts/restart_venv_and_run-server.sh
@@ -55,6 +55,8 @@ else
     done
 fi
 
+sleep 1
+
 # --- Step 4: Start the new server instance ---
 echo "Starting new server and watcher..."
 if [ -x "$SERVER_SCRIPT" ]; then

--- a/setup/macos_setup.sh
+++ b/setup/macos_setup.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# setup/macos_setup.sh
+
 set -e
 
 # --- Make script location-independent ---
@@ -31,7 +33,8 @@ if [ "$JAVA_OK" -eq 0 ]; then
 fi
 
 echo "--> Installing other core dependencies..."
-brew install fswatch wget unzip portaudio xdotool
+brew install fswatch wget unzip portaudio
+
 
 
 


### PR DESCRIPTION
feat(platform): Implement Core macOS Compatibility

Description:

This pull request introduces foundational support for running the SL5 Dictation system natively on macOS. The goal is to enable team members and future users to use the application seamlessly on both Linux and macOS environments.

This PR addresses three key areas of platform incompatibility:

File System Watching: Replaced the Linux-specific inotifywait with fswatch, which is the standard and most efficient tool for this task on macOS.

Text Automation: Replaced the xdotool dependency with the native osascript for typing the transcribed text. xdotool is not available on macOS.

Desktop Notifications: Updated the notify.py script to use osascript for sending native system notifications on macOS, as notify-send is also Linux-specific.

Changes:

setup/macos_setup.sh: Updated to install fswatch via Homebrew and removed the unnecessary xdotool dependency.

scripts/type_watcher.sh: Now detects the operating system and uses the appropriate command set (fswatch/osascript for macOS, inotifywait/xdotool for Linux).

scripts/py/func/notify.py: Now OS-aware and uses osascript to trigger native notifications on macOS.

The GitHub Actions workflow for macos_setup.yml has been run successfully on this branch, validating the setup process.

Next Steps:
Manual testing on a physical Mac is required to confirm full functionality, especially regarding system permissions for Accessibility and Notifications.