### PR TITLE
Feat/add updater script linux mac

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -7,7 +7,8 @@ set -e
 
 # --- Configuration ---
 REPO_URL="https://github.com/sl5net/Vosk-System-Listener/archive/refs/heads/master.zip"
-INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)" # Absolute path to project root
+INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 TEMP_DIR=$(mktemp -d)
 
 # --- Colors for output ---


### PR DESCRIPTION
**feat(nix): Add updater script for Linux and macOS users**

### PR Description:

This PR complements the recently added Windows updater by providing a similar, user-friendly update mechanism for Linux and macOS.

-   A new script, `update.sh`, has been added.
-   It handles the entire update process:
    1.  Checks for required dependencies (`curl`, `unzip`, `rsync`).
    2.  Downloads the latest `master` branch as a ZIP from GitHub.
    3.  Safely backs up the user's `config/settings_local.py`.
    4.  Uses `rsync` to replace the application files with the new version.
-   Users can now run this script to easily update the application without manual intervention.

This brings feature parity for the update process across all major platforms.