### PR TITLE
feat(trigger): Use intuitive name for trigger file

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ Create a new command in CopyQ with a global shortcut.
 
 **Command for Linux/macOS:**
 ```bash
-touch /tmp/vosk_trigger
+touch /tmp/sl5_record.trigger
 ```
 
 **Command for Windows use [CopyQ](https://github.com/hluk/CopyQ):**
 ```js
 copyq:
-var filePath = 'c:/tmp/vosk_trigger';
+var filePath = 'c:/tmp/sl5_record.trigger';
 
 var f = File(filePath);
 

--- a/config/languagetool_server/maps/de-DE/FUZZY_MAP.py
+++ b/config/languagetool_server/maps/de-DE/FUZZY_MAP.py
@@ -27,6 +27,8 @@ FUZZY_MAP = [
     ('pull requests', r'^pull requests$', 82),
     ('pull requests', r'^Pullover Quest$', 82),
 
+    ('feature branch', r'\bFeature prince\b', 82),
+
     ('Lauffer', r'\bLäufer\b', 100),
 
     # --- git status ---

--- a/dictation_service.py
+++ b/dictation_service.py
@@ -1,4 +1,4 @@
-# File: STT/dictation_service.py
+# File: dictation_service.py
 import os
 import sys
 
@@ -126,7 +126,6 @@ if platform.system() == "Windows":
 else:
     TMP_DIR = Path("/tmp")
 OUTPUT_FILE = TMP_DIR / "tts_output.txt"
-TRIGGER_FILE = TMP_DIR / "vosk_trigger"
 
 HEARTBEAT_FILE = TMP_DIR / "dictation_service.heartbeat"
 PIDFILE = TMP_DIR / "dictation_service.pid"

--- a/doc_sources/workflow.md
+++ b/doc_sources/workflow.md
@@ -4,13 +4,13 @@
  (e.g., DE Settings)
        |
    1. User presses Hotkey
-       |---------------------->  | 2. Creates /tmp/vosk_trigger
+       |---------------------->  | 2. Creates /tmp/sl5_record.trigger
        |                         |
 ...
 
 ```
 
-The background service waits for a `/tmp/vosk_trigger`. When your hotkey is pressed, its only job is to create this file. You can use any tool you like for this.
+The background service waits for a `/tmp/sl5_record.trigger`. When your hotkey is pressed, its only job is to create this file. You can use any tool you like for this.
 Most desktop environments (XFCE, KDE, GNOME, etc.) have a built-in keyboard shortcut manager. This is the simplest method, as it requires no extra software.
 ```
 
@@ -18,7 +18,7 @@ Most desktop environments (XFCE, KDE, GNOME, etc.) have a built-in keyboard shor
  [User/AutoKeyAutoHotKey/..]  [DictationService.py]   [tts_output.txt]        [TypeWatcher]           [Active App]
        |                         |                          |                       |                     |
    1. User presses Hotkey        |                          |                       |                     |
-       |---------------------->  | 2. Creates /tmp/vosk_trigger                     |                     |
+       |---------------------->  | 2. Creates /tmp/sl5_record.trigger                     |                     |
        |                         |                                                  |                     |
        |               (watches for trigger file)                                   |                     |
        |                         | 3. Detects & DELETES trigger file                |                     |

--- a/doc_sources/workflow_windows11.md
+++ b/doc_sources/workflow_windows11.md
@@ -4,7 +4,7 @@
   (Recommended Tool)
        |                         |                          |                             |                     |
    1. User presses Hotkey        |                          |                             |                     |
-       |---------------------->  | 2. Creates C:\tmp\vosk_trigger                         |                     |
+       |---------------------->  | 2. Creates C:\tmp\sl5_record.trigger                         |                     |
        |                         |                                                        |                     |
        |               (watches for trigger file)                                         |                     |
        |                         | 3. Detects & DELETES trigger file                      |                     |
@@ -27,7 +27,7 @@
 
 The service is activated by a simple file trigger, making it robust and flexible.
 
-*   **The Service waits** for a specific file to be created: `C:\tmp\vosk_trigger`.
+*   **The Service waits** for a specific file to be created: `C:\tmp\sl5_record.trigger`.
 *   **Your Hotkey's job** is just to create this empty file.
 *   **Recommended Tool:** For Windows, the ideal tool is **AutoHotkey (AHK)**. It's free, open-source, and already part of our toolchain.
 
@@ -38,6 +38,6 @@ The service is activated by a simple file trigger, making it robust and flexible
 ; Example: Win + Space hotkey to trigger dictation
 #Space::
 {
-    FileAppend("", "C:\tmp\vosk_trigger")
+    FileAppend("", "C:\tmp\sl5_record.trigger")
 }
 ```

--- a/scripts/autokey-scripts/live_transcribe.py
+++ b/scripts/autokey-scripts/live_transcribe.py
@@ -23,7 +23,6 @@ except (FileNotFoundError, KeyError) as e:
 
 SERVICE_PY_NAME = "dictation_service.py"
 TRIGGER_path = "/tmp/sl5_record.trigger"
-TRIGGER_path = "/tmp/vosk_trigger"
 TRIGGER_FILE = Path(TRIGGER_path)
 HEARTBEAT_FILE = Path(f"/tmp/dictation_service.heartbeat")
 # INCREASED TIMEOUT: Give the service more time to start

--- a/setup/README_docker.md
+++ b/setup/README_docker.md
@@ -2,7 +2,7 @@ docker build -t stt-service .
 
 docker run -it --rm --name stt-container stt-service
 
-docker exec stt-container touch /tmp/vosk_trigger
+docker exec stt-container touch /tmp/sl5_record.trigger
 
 
 Trying to containerize the application with Docker is a fantastic "fancy" step. It's the ultimate way to solve the "it works on my machine" problem by packaging the application and all its dependencies into a single, portable image.
@@ -35,9 +35,9 @@ With some luck, the container will build and run. You should see the log output 
 
 3.  **NO Desktop Notifications (`notify-send`):** Same as above. The container cannot send notifications to your host's desktop.
 
-4.  **NO File Trigger (`inotify`):** The `inotify`-based file trigger will not work as you expect. You cannot simply `touch /tmp/vosk_trigger` on your host machine. You would have to use a separate command to create the file *inside* the running container:
+4.  **NO File Trigger (`inotify`):** The `inotify`-based file trigger will not work as you expect. You cannot simply `touch /tmp/sl5_record.trigger` on your host machine. You would have to use a separate command to create the file *inside* the running container:
     ```bash
-    docker exec stt-container touch /tmp/vosk_trigger
+    docker exec stt-container touch /tmp/sl5_record.trigger
     ```
 
 ### Conclusion: "Fancy" but Fundamentally Incompatible


### PR DESCRIPTION
The previous file, `/tmp/vosk_trigger`, was generic and not immediately clear in its purpose.

### Changes Implemented
*   **Renamed Trigger File:** The core trigger file is now `/tmp/sl5_record.trigger`.
