### PR TITLE
fix(core): Prevent data loss on graceful stop

### DIFF
--- a/config/languagetool_server/maps/de-DE/FUZZY_MAP.py
+++ b/config/languagetool_server/maps/de-DE/FUZZY_MAP.py
@@ -38,6 +38,11 @@ FUZZY_MAP = [
     ('Branch Name', r'\bRanch Namen\b', 82),
     ('Commit', r'\bkomm mit\b', 82),
 
+    ('Commit Message', r'\bkommen mit Message\b', 82),
+
+
+    ('Code Abschnitt', r'\bKot abschnittt', 82),
+    ('StopButton', r'\bstob Button\b', 82),
 
 
 
@@ -48,6 +53,8 @@ FUZZY_MAP = [
     ('git status', r'^geht status$', 82),
     ('git status', r'^gitter status$', 82),
     ('git status', r'^geht staates$', 82),
+    ('git status', r'^Kids Dates$', 82),
+
 
     # --- git add . ---
     ('git add .', r'^Geht PET$', 82),

--- a/scripts/py/func/checks/integrity_rules.py
+++ b/scripts/py/func/checks/integrity_rules.py
@@ -24,6 +24,9 @@ INTEGRITY_CHECKS = {
     'scripts/py/func/handle_trigger.py': [
         'info("🎬 Trigger received',
         '⏹️ Manual stop trigger detected',
+        "Processing chunk:",
+        "Gracefully exiting recording loop.",
+        "Finalizing recording session:",
     ],
 
     "scripts/py/func/checks/self_tester.py": [


### PR DESCRIPTION
The recording loop now dispatches the recognized chunk for background processing *before* checking for the stop signal. This ensures that every recognized chunk is processed, even during a quick stop.

Additionally, new integrity checks have been added to monitor this behavior and confirm the graceful finalization of the session.