### PR TITLE
feat(core): Implement pre-correction fuzzy map for faster replacements

### DIFF
--- a/config/plugins/poker/dealers_choice.py
+++ b/config/plugins/poker/dealers_choice.py
@@ -1,0 +1,18 @@
+# CODE_LANGUAGE_DIRECTIVE: ENGLISH_ONLY
+# config/plugins/poker/dealers-choice.py
+import re
+
+# (key, regex, confidence_threshold, flags)
+COMMAND_MAP = [
+    # Action keys
+    ('c', r'^\s*(call|check)\s*$', 50, re.IGNORECASE),
+    ('r', r'^\s*(raise)\s*$', 50, re.IGNORECASE),
+    ('f', r'^\s*(fold)\s*$', 50, re.IGNORECASE),
+    ('d', r'^\s*(discard)\s*$', 50, re.IGNORECASE),
+    ('b', r'^\s*(bet)\s*$', 50, re.IGNORECASE),
+    ('x', r'^\s*(exchange)\s*$', 50, re.IGNORECASE),
+    # Amount keys
+    ('1', r'^\s*(100|one hundred)\s*$', 50, re.IGNORECASE),
+    ('2', r'^\s*(250|two fifty)\s*$', 50, re.IGNORECASE),
+    ('3', r'^\s*(50|fifty)\s*$', 50, re.IGNORECASE),
+]


### PR DESCRIPTION
This commit introduces a new "pre-correction" step using `FUZZY_MAP_pre.py`. This map is applied before the main LanguageTool correction, allowing for highly efficient and targeted replacements of common, predictable transcription errors.

A key optimization is included: if a pre-map rule matches the entire input string (using ^...$), the subsequent LanguageTool check is skipped entirely. This significantly improves performance for full-phrase corrections.

The text correction logic has been refactored for clarity:

- LanguageTool-specific logic is now in `correct_text_by_languagetool.py`.

The new correction pipeline is now:
1. Punctuation Map
2. FUZZY_MAP_pre (new)
3. LanguageTool (conditional)
4. FUZZY_MAP (post)
