### PR TITLE
feat(core): Make fasttext an optional, auto-installing dependency

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -10,6 +10,8 @@ current_user = os.environ.get('USERNAME', 'default')
 # e.g., the wrapper script enforcement.
 DEV_MODE = False
 
+ENABLE_AUTO_LANGUAGE_DETECTION = False
+
 # --- Notification Settings ---
 # Default for new users is the most verbose level.
 NOTIFICATION_LEVEL = 2 # 0=Silent, 1=Essential, 2=Verbose

--- a/dictation_service.py
+++ b/dictation_service.py
@@ -42,14 +42,32 @@ if 'VIRTUAL_ENV' not in os.environ:
 
 
 
-import sys, os, atexit, requests, logging, platform
+import sys, os, atexit, requests, logging, platform, importlib
 from pathlib import Path
 
 # --- Local Imports (grouped for clarity) ---
 from config.settings import (LANGUAGETOOL_RELATIVE_PATH,
                             USE_EXTERNAL_LANGUAGETOOL, EXTERNAL_LANGUAGETOOL_URL, LANGUAGETOOL_PORT,
-                            DEV_MODE
+                            DEV_MODE,
+                            ENABLE_AUTO_LANGUAGE_DETECTION
                             )
+
+
+if ENABLE_AUTO_LANGUAGE_DETECTION:
+    # Check if the package is installed without actually importing it
+    if importlib.util.find_spec("fasttext") is None:
+        logging.warning("FastText is not installed but is enabled in config.")
+        logging.info("Attempting to install 'fasttext-wheel' automatically...")
+        try:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "fasttext-wheel"])
+            logging.info("FastText installed successfully. Please restart the service to activate it.")
+            sys.exit()
+        except subprocess.CalledProcessError:
+            logging.error("Failed to install FastText. Please install it manually: pip install fasttext-wheel")
+            sys.exit(1)
+    else:
+        logging.info("FastText for auto language detection is available.")
+
 
 
 from scripts.py.func.main import main

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 cologne_phonetics==2.0.0
 comtypes==1.4.11
 config==0.5.1
-fasttext==0.9.3
 jellyfish==1.2.0
 keyboard==0.13.5
 nltk==3.9.1


### PR DESCRIPTION
This PR makes `fasttext` an optional dependency to resolve security vulnerabilities reported by Snyk. The core application no longer requires it for standard operation.

**Key Changes:**
*   `fasttext` has been removed from the main `requirements.txt`.
*   A new setting, `ENABLE_AUTO_LANGUAGE_DETECTION`, has been added to `config.py`. It is `False` by default.
*   If enabled, the service will check if `fasttext` is installed and, if not, attempt to install it automatically on the first run.

**How to Enable:**
To use the automatic language detection feature, set the following in your `config.py`:
```python
ENABLE_AUTO_LANGUAGE_DETECTION = True
```
