### PR TITLE
FEAT: Implement exception-driven private map loading with security ch…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,13 @@ config/model_name_lastused.txt
 config/maps/plugins/.privat/
 config/maps/plugins/privat/
 
+# Ignore all dot-files (passwords/keys) and dot-directories within config/maps
+config/maps/**/.*
+
+# Ignore all directories and files beginning with an underscore (_)
+# inside config/maps (this is our unencrypted working directory)
+config/maps/**/_*
+
 
 tools/translate-shell_and_save/translations
 


### PR DESCRIPTION
…eck.

The new logic is triggered when the standard import fails on a dot-prefixed .py file:
1. CRITICAL: Calls _check_gitignore_for_security to ensure 'config/maps/**/.*' and 'config/maps/**/_*' are present in .gitignore.
2. Unpacks the password-protected ZIP (if present) into a normalized '_*-prefix' working directory.
3. Normalizes the directory structure (removes the extra top-level folder).
4. Allows the main scanner to immediately load the new, unencrypted maps from the safe, git ignored directory.

Fixes the issue of slow start-up by making the logic exception-driven.