### PR TITLE
fix(thin-client): stabilize Windows execution path by replacing pytho…

### DIFF
--- a/aura_engine.py
+++ b/aura_engine.py
@@ -1216,7 +1216,7 @@ if not languagetool_process:
     try:
         from scripts.py.func.audio_manager import speak_inclusive_fallback
 
-        speak_inclusive_fallback("Language Tool is offline", "en-US")
+        speak_inclusive_fallback("wait for Language Tool", "en-US")
     except Exception as tts_err:
         logger.warning(f"Could not speak LanguageTool warning: {tts_err}")
 

--- a/scripts/py/func/start_languagetool_server.py
+++ b/scripts/py/func/start_languagetool_server.py
@@ -75,7 +75,7 @@ def _is_lt_server_responsive(url, timeout=0.9, logger=None):
         # Safe acoustic warning
         try:
             from scripts.py.func.audio_manager import speak_inclusive_fallback
-            speak_inclusive_fallback("Language Tool is offline", "en-US")
+            speak_inclusive_fallback("wait for Language Tool", "en-US")
         except Exception as tts_err:
             if logger:
                 logger.warning(f"Could not speak LanguageTool warning: {tts_err}")

--- a/scripts/py/start_uvicorn_service.py
+++ b/scripts/py/start_uvicorn_service.py
@@ -8,6 +8,11 @@ import psutil
 import time
 from pathlib import Path
 
+import os
+
+os.environ["PYTHONUTF8"] = "1"
+os.environ["PYTHONIOENCODING"] = "utf-8:replace"
+
 
 # 1. Determine the project root via your reliable temp file
 # Since we are on Linux here, /tmp is sufficient

--- a/scripts/search_rules/run_palette_command.py
+++ b/scripts/search_rules/run_palette_command.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
-# scripts/search_rules/run_palette_command.py:1
+# scripts/search_rules/run_palette_command.py:
 import sys
+
+if getattr(sys, "stdout", None) is not None:
+    encoding = getattr(sys.stdout, "encoding", None)
+    if encoding and encoding.lower() != "utf-8":
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        if getattr(sys, "stderr", None) is not None:
+            sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
     sys.stderr.reconfigure(encoding="utf-8", errors="replace")
@@ -15,19 +23,49 @@ from pathlib import Path
 import logging
 logger = logging.getLogger()
 
+try:
+    tmp_dir = Path("C:/tmp") if os.name == "nt" else Path("/tmp")
+    PROJECT_ROOT = Path((tmp_dir / "sl5_aura" / "sl5net_aura_project_root").read_text().strip())
+except Exception:
+    import traceback
+    with open(r"C:\tmp\sl5_aura\run_palette_import_error.log", "w", encoding="utf-8") as f:
+        traceback.print_exc(file=f)
+    raise
+
+# tmp_dir = Path("C:/tmp") if os.name == "nt" else Path("/tmp")
+# PROJECT_ROOT = Path((tmp_dir / "sl5_aura" / "sl5net_aura_project_root").read_text().strip())
+
+os.environ["PYTHONUTF8"] = "1"
+os.environ["PYTHONIOENCODING"] = "utf-8:replace"
+
+log_file = PROJECT_ROOT / "log" / f"{Path(__file__).stem}.log"
+log_file.parent.mkdir(parents=True, exist_ok=True)
+
+def log(msg):
+    with open(log_file, "a", encoding="utf-8") as f:
+        f.write(msg + "\n")
 
 def is_api_running():
     try:
         with socket.create_connection(("127.0.0.1", 8830), timeout=0.1):
             return True
-    except Exception: return False
+    except Exception as e:
+        print(e)
+        return False
 
 def main():
-    if len(sys.argv) < 2: sys.exit(0)
-    query = sys.argv[1]
-    SCRIPT_DIR = Path(__file__).resolve().parent
-    PROJECT_ROOT = SCRIPT_DIR.parent.parent
+    if len(sys.argv) < 2:
+        query = "Läuf"
+    else:
+        query = sys.argv[1]
+
     secrets_path = PROJECT_ROOT / ".secrets"
+
+    # Initialize debug logging for pythonw.exe execution
+    log(f"\n--- Script execution started ({time.strftime('%Y-%m-%d %H:%M:%S')}) ---\n")
+    log(f"Query argument received: '{query}'\n")
+
+    api_key = None
 
     if secrets_path.exists():
         try:
@@ -35,10 +73,22 @@ def main():
                 for line in f:
                     if line.strip().startswith("SERVICE_API_KEY="):
                         api_key = line.split("=", 1)[1].strip().strip('"').strip("'")
+                        log(f"API key loaded successfully (length: {len(api_key)} characters).\n")
                         break
         except Exception as e20260702_1708:
             print(f'e20260702_1708: {e20260702_1708}')
+            log(f'e20260702_1708: {e20260702_1708}')
+    else:
+        log("FATAL: SERVICE_API_KEY missing (no .secrets found on Windows)\n")
+        raise RuntimeError("Missing SERVICE_API_KEY")
 
+    if not api_key:
+        log_file = PROJECT_ROOT / "log" / "run_palette_command.log"
+        with open(log_file, "a", encoding="utf-8") as lf:
+            log("ERROR: API key not loaded\n")
+        raise RuntimeError("API key missing")
+
+    log(f"secrets_path exists: {secrets_path.exists()}\n")
 
     # DEBUG_LOG = PROJECT_ROOT / "log" / "palette_launch_debug.log"
     # with open(DEBUG_LOG, "a", encoding="utf-8") as lf:
@@ -61,7 +111,8 @@ def main():
         except Exception as e20260702_1707:
             print(f'e20260702_1707: {e20260702_1707}')
 
-
+    if not is_api_running():
+        time.sleep(3)
     if not is_api_running():
         print("🚀 Starting FastAPI Uvicorn Service in background...", flush=True)
         # CREATE_NO_WINDOW = 0x08000000
@@ -72,7 +123,7 @@ def main():
         flags = subprocess.DETACHED_PROCESS
         kwargs = {"start_new_session": True} if os.name != "nt" else {"creationflags": flags}
 
-        DEBUG_LOG = PROJECT_ROOT / "log" / "palette_launch_debug.log"
+        DEBUG_LOG = PROJECT_ROOT / "log" / f"{Path(__file__).stem}.log"
         with open(DEBUG_LOG, "a", encoding="utf-8") as lf:
             subprocess.Popen(
                 [sys.executable, str(PROJECT_ROOT / "scripts" / "py" / "start_uvicorn_service.py")],
@@ -83,9 +134,26 @@ def main():
         #     [sys.executable, str(PROJECT_ROOT / "scripts" / "py" / "start_uvicorn_service.py")],
         #     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,  env=env, **kwargs
         # )
-        for _ in range(40):
-            if is_api_running(): break
+        # for _ in range(40):
+        #     if is_api_running(): break
+        #     time.sleep(0.1)
+
+        # Wait for the API to become responsive
+        api_ready = False
+        for attempt in range(1, 140):
+            if is_api_running():
+                api_ready = True
+                log(f"Uvicorn service became responsive after {attempt * 100}ms (attempt {attempt}).\n")
+                break
             time.sleep(0.1)
+
+        if not api_ready:
+            log("WARNING: Uvicorn service failed to respond within 4.0 seconds timeout.\n")
+
+
+
+
+
 
     # payload = {"raw_text": query, "lang_code": "de-DE", "unmasked": False}
     payload = {"raw_text": query, "lang_code": "de-DE", "unmasked": False, "interface": "speech"}
@@ -101,19 +169,32 @@ def main():
             res_data = json.loads(response.read().decode("utf-8"))
             if res_data.get("status") == "completed":
                 result_text = res_data.get("result_text", "")
-                print(result_text)
 
-                # Schreibe die Ausgabedatei für Hintergrund-Watcher (Master-Kompatibilität)
                 tmp_dir = Path("C:/tmp") if os.name == 'nt' else Path("/tmp")
                 output_dir = tmp_dir / "sl5_aura" / "tts_output"
-                output_dir.mkdir(parents=True, exist_ok=True)
-                out_file = output_dir / f"tts_output_{int(time.time() * 1000)}.txt"
-                with open(out_file, "w", encoding="utf-8") as f:
-                    f.write(result_text)
+
+                log_file = PROJECT_ROOT / "log" / f"{Path(__file__).stem}.log"
+                log_file.parent.mkdir(parents=True, exist_ok=True)
+
+                with open(log_file, "a", encoding="utf-8") as lf:
+                    log(f"--- try ({time.strftime('%H:%M:%S')}) ---\n")
+                    log(f"output_dir: {output_dir}\n")
+                    try:
+                        output_dir.mkdir(parents=True, exist_ok=True)
+                        out_file = output_dir / f"tts_output_{int(time.time() * 1000)}.txt"
+                        with open(out_file, "w", encoding="utf-8") as f:
+                            f.write(result_text)
+                        log(f"success: file wrote -> {out_file}\n")
+                    except PermissionError as pe:
+                        log(f"ERROR (rights): {pe}\n")
+                    except Exception as ex:
+                        log(f"ERROR : {ex}\n")
             else:
-                print(f"Service-Antwort (Fehler): {res_data}")
+                print(f"ERROR Service-answer : {res_data}")
     except Exception as e:
-        print(f"Verbindungsfehler (Port 8830): {e}", file=sys.stderr)
+        # Write connection/runtime errors to log file since pythonw.exe suppresses stderr
+        log(f"ERROR (API connection or runtime failure): {type(e).__name__} - {e}\n")
+        print(f"connection error (Port 8830): {e}", file=sys.stderr)
 
 if __name__ == '__main__':
     main()

--- a/scripts/search_rules/search_rules.ps1
+++ b/scripts/search_rules/search_rules.ps1
@@ -7,6 +7,10 @@ param(
 # -----------------------------------------------------------------------------
 # CONFIGURATION & DEFAULTS
 # -----------------------------------------------------------------------------
+
+$env:PYTHONUTF8 = "1"
+$env:PYTHONIOENCODING = "utf-8:replace"
+
 $MY_HOME = [Environment]::GetFolderPath("UserProfile")
 $SCRIPT_DIR   = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $PROJECT_ROOT = Split-Path -Parent (Split-Path -Parent $SCRIPT_DIR)
@@ -16,7 +20,10 @@ $ENABLE_LOGGING = $true
 $ErrorActionPreference = 'Stop'
 $LOG_DIR = Join-Path $PROJECT_ROOT "log"
 if (-not (Test-Path $LOG_DIR)) { [void](New-Item -ItemType Directory -Path $LOG_DIR -Force) }
-$LOGFILE = Join-Path $LOG_DIR "search_rules_ps1_debug.log"
+
+$ScriptName = [System.IO.Path]::GetFileNameWithoutExtension((Get-Variable MyInvocation -Scope Script).Value.MyCommand.Path)
+$LOGFILE = Join-Path $LOG_DIR "${ScriptName}.log"
+
 #function DBG { param($m) "$(Get-Date -Format o) - $m" | Out-File -FilePath $LOGFILE -Append -Encoding utf8 }
 
 function DBG {
@@ -32,11 +39,12 @@ DBG "EXACT RUNNING PATH: $($MyInvocation.MyCommand.Definition)"
 
 $PYTHON_BIN = Join-Path $PROJECT_ROOT ".venv\Scripts\python.exe"
 if (-not (Test-Path $PYTHON_BIN)) { $PYTHON_BIN = "python.exe" }
-$PYTHONW_BIN = Join-Path $PROJECT_ROOT ".venv\Scripts\pythonw.exe"
+#$PYTHONW_BIN = Join-Path $PROJECT_ROOT ".venv\Scripts\pythonw.exe"
+$PYTHONW_BIN = Join-Path $PROJECT_ROOT ".venv\Scripts\python.exe"
 if (-not (Test-Path $PYTHONW_BIN)) { $PYTHONW_BIN = $PYTHON_BIN }
 
 
-
+# scripts/search_rules/search_rules.ps1:42
 # MAPS_DIR priority: param > env MAPS_DIR > default relative to project root
 if (-not $MAPS_DIR) { $MAPS_DIR = $env:MAPS_DIR }
 if (-not $MAPS_DIR) { $MAPS_DIR = Join-Path $PROJECT_ROOT "config\maps" }
@@ -404,19 +412,54 @@ while ($true) {
             DBG "DEBUG: Fallback to typed query: '$EXEC_QUERY'"
         }
 
+        DBG "EXEC_QUERY: '$EXEC_QUERY'"
+
+#        DBG "DEBUG: try Executing run_palette_command: PYW_EXE:$PYW_EXE RUN_CMD:$RUN_CMD with query: '$EXEC_QUERY'"
+
        if ($EXEC_QUERY) {
             $RUN_CMD = Join-Path $SCRIPT_DIR "run_palette_command.py"
-            $PYW = Join-Path $PROJECT_ROOT ".venv\Scripts\pythonw.exe"
-            $PYW_EXE = if (Test-Path $PYW) { $PYW } else { "pythonw" }
-            DBG "DEBUG: Executing run_palette_command: $PYW_EXE $RUN_CMD with query: '$EXEC_QUERY'"
+            $PYW = Join-Path $PROJECT_ROOT ".venv\Scripts\python.exe"
+            $PYW_EXE = if (Test-Path $PYW) { $PYW } else { "python" }
+
+            DBG "RUN_CMD: $RUN_CMD"
+            DBG "PYW_EXE: $PYW_EXE"
+            DBG "RUN_CMD exists: $(Test-Path $RUN_CMD)"
+            DBG "PYW_EXE exists: $(Test-Path $PYW_EXE)"
+            DBG "EXEC_QUERY: '$EXEC_QUERY'"
+
+
             try {
+
+                DBG "Calling Start-Process..."
+
+                $proc = Start-Process `
+                    -FilePath $PYW_EXE `
+                    -ArgumentList "`"$RUN_CMD`"", "`"$EXEC_QUERY`"" `
+                    -WindowStyle Hidden `
+                    -PassThru
+
+                DBG "Start-Process returned."
+                DBG "PID: $($proc.Id)"
+
+                Start-Sleep -Milliseconds 200
+
+                DBG "HasExited: $($proc.HasExited)"
+
+                if ($proc.HasExited) {
+                    DBG "ExitCode: $($proc.ExitCode)"
+                }
+
+
+
+
 #                Start-Process -FilePath $PYW_EXE -ArgumentList "`"$RUN_CMD`"", "`"$EXEC_QUERY`"" -NoNewWindow
-                Start-Process -FilePath $PYW_EXE -ArgumentList "`"$RUN_CMD`"", "`"$EXEC_QUERY`"" -WindowStyle Hidden
+#                Start-Process -FilePath $PYW_EXE -ArgumentList "`"$RUN_CMD`"", "`"$EXEC_QUERY`"" -WindowStyle Hidden
             } catch {
                 DBG "DEBUG: Start-Process failed: $_"
             }
         }
         if ($SEARCH_CLOSE_ON_OPEN -eq "True") {
+            DBG "DEBUG: $SEARCH_CLOSE_ON_OPEN is true -> exit 0"
             exit 0
         } else { Start-Sleep -Milliseconds 300; continue }
     }


### PR DESCRIPTION
…nw with python for CLI flow

- Confirm correct behavior of F12 → AHK → search_rules.ps1 → run_palette_command.py pipeline using python.exe
- Keep uvicorn background service separation intact while ensuring CLI reliability

Note: pythonw is retained for non-critical background GUI/background tasks (to avoid a console window). It is no longer used for core CLI command execution because it suppresses/redirects console I/O and can cause silent failures.