### PR TITLE
Ci/container dotool test

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -2,8 +2,7 @@ name: Mirror to Codeberg
 
 on:
   push:
-    branches:
-      - '**'
+    branches: [ master ]
   delete:
   workflow_dispatch:
 

--- a/.github/workflows/self-test-container.yml
+++ b/.github/workflows/self-test-container.yml
@@ -2,7 +2,7 @@ name: Self-Test (Container Aura & Input)
 # .github/workflows/self-test-container.yml
 on:
   push:
-    branches: [ master ]
+    branches: [ master, ci/container-dotool-test ]
   pull_request:
     branches: [ master ]
     paths-ignore:

--- a/setup/.draft-not-ready/Dockerfile
+++ b/setup/.draft-not-ready/Dockerfile
@@ -45,8 +45,11 @@ RUN rm -rf /app/.venv && chown -R runner:runner /app
 
 USER runner
 
-# Run diagnostics to verify user identity, directory ownership, and write permissions
-RUN whoami && ls -ld /app && mkdir -p /app/test_write && rm -rf /app/test_write
+# Cache-breaker to force diagnostic execution and show output in build logs
+RUN echo "Force build update 2" && whoami && ls -la /app
+
+# Test if runner can manually create a python venv here in a clean directory
+RUN python3 -m venv /app/.venv_test_manual && rm -rf /app/.venv_test_manual
 
 # Initialize configuration and Python virtual environment
 RUN cp -f config/settings_local.py_Example.txt config/settings_local.py || true && \

--- a/setup/.draft-not-ready/Dockerfile
+++ b/setup/.draft-not-ready/Dockerfile
@@ -39,8 +39,11 @@ RUN mkdir -p /tmp/sl5_aura && \
 
 WORKDIR /app
 
-# Copy repository files and set permissions
+WORKDIR /app
+
+# Copy the repository files and set permissions
 COPY --chown=runner:runner . /app
+RUN chown runner:runner /app
 
 USER runner
 

--- a/setup/.draft-not-ready/Dockerfile
+++ b/setup/.draft-not-ready/Dockerfile
@@ -46,10 +46,10 @@ RUN rm -rf /app/.venv && chown -R runner:runner /app
 USER runner
 
 # Run diagnostics to verify user identity, directory ownership, and write permissions
-RUN echo "Force build update 3" && whoami && ls -la /app
+#RUN echo "Force build update 3" && whoami && ls -la /app
 
 # Test if runner can manually create a python venv here in a clean directory
-RUN python3 -m venv /app/.venv_test_manual && rm -rf /app/.venv_test_manual
+#RUN python3 -m venv /app/.venv_test_manual && rm -rf /app/.venv_test_manual
 
 # Initialize configuration and Python virtual environment
 RUN cp -f config/settings_local.py_Example.txt config/settings_local.py || true && \

--- a/setup/.draft-not-ready/Dockerfile
+++ b/setup/.draft-not-ready/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     sudo \
     scdoc \
     libxkbcommon-dev \
+    software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
 # Build dotool from source

--- a/setup/.draft-not-ready/Dockerfile
+++ b/setup/.draft-not-ready/Dockerfile
@@ -45,7 +45,10 @@ RUN rm -rf /app/.venv && chown -R runner:runner /app
 
 USER runner
 
-# Ensure local example config is copied and run official Ubuntu setup
+# Run diagnostics to verify user identity, directory ownership, and write permissions
+RUN whoami && ls -ld /app && mkdir -p /app/test_write && rm -rf /app/test_write
+
+# Initialize configuration and Python virtual environment
 RUN cp -f config/settings_local.py_Example.txt config/settings_local.py || true && \
     if [ -f ./setup/ubuntu_setup.sh ]; then bash ./setup/ubuntu_setup.sh; fi
 

--- a/setup/.draft-not-ready/Dockerfile
+++ b/setup/.draft-not-ready/Dockerfile
@@ -1,4 +1,4 @@
-# Use Ubuntu 22.04 LTS as stable base
+# Use Ubuntu LTS as stable base
 FROM ubuntu:22.04
 
 # Prevent interactive prompts during package installation

--- a/setup/.draft-not-ready/Dockerfile
+++ b/setup/.draft-not-ready/Dockerfile
@@ -39,11 +39,9 @@ RUN mkdir -p /tmp/sl5_aura && \
 
 WORKDIR /app
 
-WORKDIR /app
-
 # Copy the repository files and set permissions
 COPY --chown=runner:runner . /app
-RUN chown runner:runner /app
+RUN rm -rf /app/.venv && chown -R runner:runner /app
 
 USER runner
 

--- a/setup/.draft-not-ready/Dockerfile
+++ b/setup/.draft-not-ready/Dockerfile
@@ -1,5 +1,5 @@
 # Use Ubuntu LTS as stable base
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive

--- a/setup/.draft-not-ready/Dockerfile
+++ b/setup/.draft-not-ready/Dockerfile
@@ -32,7 +32,7 @@ RUN groupadd -f input && \
     usermod -aG input runner && \
     echo "runner ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# Prepare Bootstrap Pointer (The Master Key) for Aura
+# Prepare Bootstrap Pointer (The Master Key)
 RUN mkdir -p /tmp/sl5_aura && \
     chmod -R 777 /tmp/sl5_aura && \
     echo "/app" > /tmp/sl5_aura/sl5net_aura_project_root
@@ -45,8 +45,8 @@ RUN rm -rf /app/.venv && chown -R runner:runner /app
 
 USER runner
 
-# Cache-breaker to force diagnostic execution and show output in build logs
-RUN echo "Force build update 2" && whoami && ls -la /app
+# Run diagnostics to verify user identity, directory ownership, and write permissions
+RUN echo "Force build update 3" && whoami && ls -la /app
 
 # Test if runner can manually create a python venv here in a clean directory
 RUN python3 -m venv /app/.venv_test_manual && rm -rf /app/.venv_test_manual
@@ -55,5 +55,5 @@ RUN python3 -m venv /app/.venv_test_manual && rm -rf /app/.venv_test_manual
 RUN cp -f config/settings_local.py_Example.txt config/settings_local.py || true && \
     if [ -f ./setup/ubuntu_setup.sh ]; then bash ./setup/ubuntu_setup.sh; fi
 
-ENV DISPLAY=:99
+# Default to bash shell
 CMD ["bash"]


### PR DESCRIPTION
- Add a containerized E2E typing simulation test to CI (.github/workflows/self-test-container.yml) using uinput mapping.

- Upgrade Dockerfile base image to Ubuntu 24.04 to natively support NumPy 2.4.2 under Python 3.12.

- Compile dotool from sourcehut (~geb) inside the container using scdoc and libxkbcommon-dev.
